### PR TITLE
fix documentation of overlayClassName property

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ var Dropdown = require('rc-dropdown');
     </thead>
     <tbody>
         <tr>
-          <td>className</td>
+          <td>overlayClassName</td>
           <td>String</td>
           <td></td>
           <td>additional css class of root dom node</td>


### PR DESCRIPTION
I guess this is a typo on the [documentation](https://github.com/react-component/dropdown#props), see https://github.com/react-component/dropdown/blob/master/src/Dropdown.jsx#L18