### PR TITLE
Allow diff visible change between select item and other

### DIFF
--- a/src/Dropdown.jsx
+++ b/src/Dropdown.jsx
@@ -71,20 +71,18 @@ const Dropdown = React.createClass({
   onClick(e) {
     const props = this.props;
     const overlayProps = props.overlay.props;
-    this.onVisibleChange(false);
+    this.onVisibleChange(false, e);
     if (overlayProps.onClick) {
       overlayProps.onClick(e);
     }
   },
 
-  onVisibleChange(visible) {
+  onVisibleChange(visible, e) {
     const props = this.props;
     if (!('visible' in props)) {
-      this.setState({
-        visible,
-      });
+      this.setState({ visible });
     }
-    props.onVisibleChange(visible);
+    props.onVisibleChange(visible, e);
   },
 
   getMenuElement() {


### PR DESCRIPTION
fix issue ant-design/ant-design#2507 broken by f6ff403

需要加一个参数，区分正常的显隐和选择菜单后的隐藏这两种情况，以实现`选择菜单时不关闭浮层的受控模式`：https://github.com/ant-design/ant-design/pull/2509