### PR TITLE
Make rc-dropdown compatible with Inferno/Preact

### DIFF
--- a/src/Dropdown.jsx
+++ b/src/Dropdown.jsx
@@ -108,7 +108,7 @@ export default class Dropdown extends Component {
     if (visible && this.props.minOverlayWidthMatchTrigger) {
       const overlayNode = this.getPopupDomNode();
       const rootNode = ReactDOM.findDOMNode(this);
-      if (rootNode.offsetWidth > overlayNode.offsetWidth) {
+      if (rootNode && overlayNode && rootNode.offsetWidth > overlayNode.offsetWidth) {
         overlayNode.style.width = `${rootNode.offsetWidth}px`;
         if (this.trigger &&
             this.trigger._component &&


### PR DESCRIPTION
When using Inferno instead of React, I'm getting the following error when closing a dropdown:

Uncaught TypeError: Cannot read property 'offsetWidth' of null
    at Object.afterVisibleChange [as afterPopupVisibleChange] (Dropdown.js:204)

This change should fix the bug. I guess it's also related to https://github.com/ant-design/ant-design/issues/5701