### PR TITLE
Add react and react-dom as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "typescript": "^4.0.2"
   },
   "peerDependencies": {
-    "react": "*",
-    "react-dom": "*"
+    "react": ">=16.9.0",
+    "react-dom": ">=16.9.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.10.1",


### PR DESCRIPTION
Fixes errors using Yarn 2 (berry).

See https://github.com/ant-design/ant-design/issues/27339 for details.
