### PR TITLE
fix(Dropdown): renderChildren use mergedVisible for calculation

### DIFF
--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
-import Trigger, { TriggerProps } from 'rc-trigger';
+import Trigger from 'rc-trigger';
+import type { TriggerProps } from 'rc-trigger';
 import classNames from 'classnames';
-import { AnimationType, AlignType, BuildInPlacements, ActionType } from 'rc-trigger/lib/interface';
+import type {
+  AnimationType,
+  AlignType,
+  BuildInPlacements,
+  ActionType,
+} from 'rc-trigger/lib/interface';
 import Placements from './placements';
 
 export interface DropdownProps
@@ -84,11 +90,11 @@ function Dropdown(props: DropdownProps, ref) {
     }
   };
 
-  const onVisibleChange = (visible: boolean) => {
-    const { onVisibleChange } = props;
-    setTriggerVisible(visible);
-    if (typeof onVisibleChange === 'function') {
-      onVisibleChange(visible);
+  const onVisibleChange = (newVisible: boolean) => {
+    const { onVisibleChange: onVisibleChangeProp } = props;
+    setTriggerVisible(newVisible);
+    if (typeof onVisibleChangeProp === 'function') {
+      onVisibleChangeProp(newVisible);
     }
   };
 
@@ -138,7 +144,7 @@ function Dropdown(props: DropdownProps, ref) {
     const { children } = props;
     const childrenProps = children.props ? children.props : {};
     const childClassName = classNames(childrenProps.className, getOpenClassName());
-    return triggerVisible && children
+    return mergedVisible && children
       ? React.cloneElement(children, {
           className: childClassName,
         })

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -42,6 +42,26 @@ describe('dropdown', () => {
       </Dropdown>,
     );
     expect(getPopupDomNode(dropdown) instanceof HTMLDivElement).toBeTruthy();
+    expect(dropdown.find('.my-button').hasClass('rc-dropdown-open')).toBe(true);
+  });
+
+  it('supports constrolled visible prop', () => {
+    const onVisibleChange = jest.fn();
+    const dropdown = mount(
+      <Dropdown
+        overlay={<div className="check-for-visible">Test</div>}
+        visible
+        trigger={['click']}
+        onVisibleChange={onVisibleChange}
+      >
+        <button className="my-button">open</button>
+      </Dropdown>,
+    );
+    expect(getPopupDomNode(dropdown) instanceof HTMLDivElement).toBeTruthy();
+    expect(dropdown.find('.my-button').hasClass('rc-dropdown-open')).toBe(true);
+
+    dropdown.find('.my-button').simulate('click');
+    expect(onVisibleChange).toHaveBeenCalledWith(false);
   });
 
   it('simply works', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "declaration": true,
+    "module": "esnext",
+    "target": "esnext",
+    "moduleResolution": "node",
+    "jsx": "react",
+    "skipLibCheck": true
+  },
+  "include": ["./src", "./typings/"],
+  "typings": "./typings/index.d.ts",
+  "exclude": [
+    "node_modules",
+    "build",
+    "scripts",
+    "acceptance-tests",
+    "webpack",
+    "jest",
+    "src/setupTests.ts",
+    "tslint:latest",
+    "tslint-config-prettier"
+  ]
+}
+  


### PR DESCRIPTION
renderChildren使用triggerVisible导致受控时上下层组件状态不一致。此处改为mergedVisible