### PR TITLE
Fix crash in useAccessibility

### DIFF
--- a/src/hooks/useAccessibility.ts
+++ b/src/hooks/useAccessibility.ts
@@ -67,7 +67,7 @@ export default function useAccessibility({
     if (visible && triggerRef.current) {
       if (triggerRef.current.triggerRef.current) {
         setTimeout(() => {
-          triggerRef.current.triggerRef.current.focus();
+          triggerRef.current?.triggerRef?.current?.focus();
         }, 100);
       }
     }


### PR DESCRIPTION
There is an issue in `useAccessibility` usage of `setTimeout`.

It's possible that `triggerRef.current` will be already `null` when `triggerRef.current.triggerRef.current.focus();` is executed.

Imagine following:
- there is a link in dropdown
- user click the link
- this will trigger the `setTimeout`
- user is navigated to different page (dropdown is unmounted, `triggerRef.current` is set to `null`)
- 100ms timeout passes and `triggerRef.current.triggerRef.current.focus();`
- user gets runtime error: `useAccessibility.js?5e4c:69 Uncaught TypeError: Cannot read properties of null (reading 'triggerRef')`