### PR TITLE
fix(Dropdown): visibility is controlled when undefined

### DIFF
--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -63,7 +63,7 @@ function Dropdown(props: DropdownProps, ref) {
   } = props;
 
   const [triggerVisible, setTriggerVisible] = React.useState<boolean>();
-  const mergedVisible = 'visible' in props ? visible : triggerVisible;
+  const mergedVisible = visible !== undefined ? visible : triggerVisible;
 
   const triggerRef = React.useRef(null);
   React.useImperativeHandle(ref, () => triggerRef.current);

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -45,7 +45,7 @@ describe('dropdown', () => {
     expect(dropdown.find('.my-button').hasClass('rc-dropdown-open')).toBe(true);
   });
 
-  it('supports constrolled visible prop', () => {
+  it('supports controlled visible prop', () => {
     const onVisibleChange = jest.fn();
     const dropdown = mount(
       <Dropdown
@@ -86,7 +86,12 @@ describe('dropdown', () => {
       </Menu>
     );
     const dropdown = mount(
-      <Dropdown trigger={['click']} overlay={menu} onOverlayClick={onOverlayClick}>
+      <Dropdown
+        trigger={['click']}
+        overlay={menu}
+        onOverlayClick={onOverlayClick}
+        visible={undefined}
+      >
         <button className="my-button">open</button>
       </Dropdown>,
     );


### PR DESCRIPTION
Currently, react-component/dropdown checks the _existance_ of the visibility key in props to determine whether or not the visibility prop is controlled or not. However, it should check for undefined instead. This will support the following behavior:


```typescript
interface IMyDropdownWrapperProps {
   myProp1: string;
   visible?: boolean;
   onVisibleChange?: (visible: boolean) => void;
}


const MyDropdownWrapper: React.FC<IMyDropdownWrapperProps > = ({
  myProp1,
  visible,
  onVisibleChange
}) => {
  return (
    <Dropdown
      // ISSUE: visible is now ALWAYS controlled, even though it may be undefined, which is not standard
      visible={visible}
      onVisibleChange={onVisibleChange}
   >
     My Dropdown
   </Dropdown>
}
```

A workaround would be to use the spread operator or something similar to ensure that if visible is undefined, we don't pass down the visible key