### PR TITLE
chore: remove return focus

### DIFF
--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -71,7 +71,7 @@ function Dropdown(props: DropdownProps, ref) {
   const menuRef = React.useRef(null);
   const menuClassName = `${prefixCls}-menu`;
 
-  const { returnFocus } = useAccessibility({
+  useAccessibility({
     visible: mergedVisible,
     setTriggerVisible,
     triggerRef,
@@ -101,7 +101,6 @@ function Dropdown(props: DropdownProps, ref) {
     if (overlayProps.onClick) {
       overlayProps.onClick(e);
     }
-    returnFocus();
   };
 
   const onVisibleChange = (newVisible: boolean) => {

--- a/src/hooks/useAccessibility.ts
+++ b/src/hooks/useAccessibility.ts
@@ -57,16 +57,4 @@ export default function useAccessibility({
     }
     return () => null;
   }, [visible]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const returnFocus = () => {
-    if (visible) {
-      setTimeout(() => {
-        triggerRef.current?.triggerRef?.current?.focus?.();
-      }, 100);
-    }
-  };
-
-  return {
-    returnFocus,
-  };
 }

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -448,4 +448,25 @@ describe('dropdown', () => {
     jest.runAllTimers();
     jest.useRealTimers();
   });
+
+  it('should not return focus if controlled visible', async () => {
+    const mockFocus = jest.fn();
+    const overlay = (
+      <Menu>
+        <MenuItem key="1">
+          <span className="my-menuitem">one</span>
+        </MenuItem>
+        <MenuItem key="2">two</MenuItem>
+      </Menu>
+    );
+    const dropdown = mount(
+      <Dropdown visible trigger={['click']} overlay={overlay}>
+        <button className="my-button" onFocus={mockFocus}>
+          open
+        </button>
+      </Dropdown>,
+    );
+    dropdown.find('.my-menuitem').simulate('click');
+    expect(mockFocus).not.toHaveBeenCalled();
+  });
 });

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -448,25 +448,4 @@ describe('dropdown', () => {
     jest.runAllTimers();
     jest.useRealTimers();
   });
-
-  it('should not return focus if controlled visible', async () => {
-    const mockFocus = jest.fn();
-    const overlay = (
-      <Menu>
-        <MenuItem key="1">
-          <span className="my-menuitem">one</span>
-        </MenuItem>
-        <MenuItem key="2">two</MenuItem>
-      </Menu>
-    );
-    const dropdown = mount(
-      <Dropdown visible trigger={['click']} overlay={overlay}>
-        <button className="my-button" onFocus={mockFocus}>
-          open
-        </button>
-      </Dropdown>,
-    );
-    dropdown.find('.my-menuitem').simulate('click');
-    expect(mockFocus).not.toHaveBeenCalled();
-  });
 });


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/34532﻿
Focus trigger when click menu will cause some issues, so this feature was temporarily removed.