### PR TITLE
Add correct type definition to `placement` prop

### DIFF
--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -32,7 +32,7 @@ export interface DropdownProps
   animation?: AnimationType;
   align?: AlignType;
   overlayStyle?: React.CSSProperties;
-  placement?: string;
+  placement?: keyof typeof Placements;
   placements?: BuildInPlacements;
   overlay?: (() => React.ReactElement) | React.ReactElement;
   trigger?: ActionType | ActionType[];


### PR DESCRIPTION
I spent 2 hours figuring out why my dropdown is not working. Then I realized I used "bottom" as placement which looks like in the `rc-tooltip` library. I added the strict type to the `placement` prop so no one won't loses time figuring out what placement is like