### PR TITLE
Expose type autoDestroy from @rc-component/trigger & fix test coverage

### DIFF
--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -23,6 +23,7 @@ export interface DropdownProps
     | 'mouseLeaveDelay'
     | 'onPopupAlign'
     | 'builtinPlacements'
+    | 'autoDestroy'
   > {
   minOverlayWidthMatchTrigger?: boolean;
   arrow?: boolean;

--- a/tests/__snapshots__/basic.test.tsx.snap
+++ b/tests/__snapshots__/basic.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`dropdown simply works 1`] = `
   </button>
   <div
     class="rc-dropdown rc-dropdown-placement-bottomLeft"
-    style="left: -1000vw; top: -1000vh; box-sizing: border-box;"
+    style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box; min-width: 100px;"
   >
     <ul
       class="rc-menu rc-menu-root rc-menu-vertical"
@@ -32,6 +32,7 @@ exports[`dropdown simply works 1`] = `
       </li>
       <li
         class="rc-menu-item-divider"
+        role="separator"
       />
       <li
         class="rc-menu-item"


### PR DESCRIPTION
Exposed `autoDestroy` prop in `rc-dropdown` from `TriggerProps` as its useful when we need to destroy after dropdown close for custom overlay. Currently for this hack is required and need to extend TriggerProps manually with `@rc-component/trigger`