### PR TITLE
[enhancement] flexible export from root for props

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,7 @@
-import Dropdown from './Dropdown'
+export type { TriggerProps } from '@rc-component/trigger';
+export type { DropdownProps } from './Dropdown';
+export type { OverlayProps } from './Overlay';
 
-export default Dropdown
+import Dropdown from './Dropdown';
+
+export default Dropdown;


### PR DESCRIPTION
## DropdownProps
### Before
`import { DropdownProps } from 'rc-dropdown/lib/Dropdown';`

### Now
<div>
<code>import { DropdownProps } from 'rc-dropdown/lib/Dropdown';</code>
</br>
<code>import { DropdownProps } from 'rc-dropdown';</code>
</div>

## OverlayProps
### Before
`import { OverlayProps } from 'rc-dropdown/lib/Overlay';`

### Now
<div>
<code>import { OverlayProps } from 'rc-dropdown/lib/Overlay';</code>
</br>
<code>import { OverlayProps } from 'rc-dropdown';</code>
</div>

## TriggerProps
### Before
Not supported

**Hack**
install: `@rc-component/trigger`
`import { TriggerProps } from '@rc-component/trigger';`

### Now
<div>
<code>import { TriggerProps } from 'rc-dropdown';</code>
</br>
<code>import { TriggerProps } from 'rc-dropdown/lib/Dropdown';</code>
</div>

### Why need TriggerProps ?
We pass all rest props to Trigger (@rc-component/trigger), for advance customization we required that support in `ts` so we can skip extra install @rc-component/trigger, with install externally it can lead issue because of version miss match.