### PR TITLE
Avoid rc package deep imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,11 +45,11 @@
   },
   "dependencies": {
     "@rc-component/trigger": "^3.0.0",
-    "@rc-component/util": "^1.2.1",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.2",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/menu": "^1.0.0",
     "@rc-component/np": "^1.0.3",
     "@rc-component/resize-observer": "^1.0.0",

--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -1,12 +1,11 @@
-import type {
-  ActionType,
-  AlignType,
-  AnimationType,
-  BuildInPlacements,
-  TriggerProps,
-  TriggerRef,
+import Trigger, {
+  type ActionType,
+  type AlignType,
+  type AnimationType,
+  type BuildInPlacements,
+  type TriggerProps,
+  type TriggerRef,
 } from '@rc-component/trigger';
-import Trigger from '@rc-component/trigger';
 import { composeRef, getNodeRef, supportRef } from '@rc-component/util';
 import { clsx } from 'clsx';
 import React from 'react';

--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -1,12 +1,13 @@
-import type { TriggerProps, TriggerRef } from '@rc-component/trigger';
-import Trigger from '@rc-component/trigger';
 import type {
   ActionType,
   AlignType,
   AnimationType,
   BuildInPlacements,
-} from '@rc-component/trigger/lib/interface';
-import { composeRef, getNodeRef, supportRef } from '@rc-component/util/lib/ref';
+  TriggerProps,
+  TriggerRef,
+} from '@rc-component/trigger';
+import Trigger from '@rc-component/trigger';
+import { composeRef, getNodeRef, supportRef } from '@rc-component/util';
 import { clsx } from 'clsx';
 import React from 'react';
 import useAccessibility from './hooks/useAccessibility';

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -1,4 +1,4 @@
-import { composeRef, getNodeRef, supportRef } from '@rc-component/util/lib/ref';
+import { composeRef, getNodeRef, supportRef } from '@rc-component/util';
 import React, { forwardRef, useMemo } from 'react';
 import type { DropdownProps } from './Dropdown';
 

--- a/src/hooks/useAccessibility.ts
+++ b/src/hooks/useAccessibility.ts
@@ -1,5 +1,4 @@
-import KeyCode from '@rc-component/util/lib/KeyCode';
-import raf from '@rc-component/util/lib/raf';
+import { KeyCode, raf } from '@rc-component/util';
 import * as React from 'react';
 
 const { ESC, TAB } = KeyCode;

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -2,7 +2,7 @@
 import type { MenuRef } from '@rc-component/menu';
 import Menu, { Divider, Item as MenuItem } from '@rc-component/menu';
 import { _rs } from '@rc-component/resize-observer';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import { spyElementPrototypes } from '@rc-component/util';
 import { act, fireEvent } from '@testing-library/react';
 import type { HTMLAttributes } from 'react';
 import * as React from 'react';


### PR DESCRIPTION
## 背景

antd 侧限制继续使用 rc 包的 `lib` / `es` 深路径导入，需要将 dropdown 中对 rc 包内部路径的依赖迁移到包根入口。

## 调整内容

- 升级 `@rc-component/father-plugin`，使用插件统一拦截 rc 包 `lib` / `es` 深路径导入。
- 升级 `@rc-component/util`。
- 将源码中对 `@rc-component/util` 和 `@rc-component/trigger` 内部路径的引用改为从包根入口导入。
- 将测试中 `spyElementPrototypes` 改为从 `@rc-component/util` 根入口导入。

## 验证

- 本次按本地核对后的改动提交。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 升级依赖包版本

* **Refactor**
  * 优化模块导入路径，改进代码组织方式

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/dropdown/pull/246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->