### PR TITLE
fix: do not forward disabled to trigger

### DIFF
--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -65,8 +65,9 @@ const Dropdown = React.forwardRef<TriggerRef, DropdownProps>((props, ref) => {
     overlay,
     children,
     onVisibleChange,
+    disabled,
     ...otherProps
-  } = props;
+  } = props as DropdownProps & { disabled?: boolean };
 
   const [triggerVisible, setTriggerVisible] = React.useState<boolean>();
   const mergedVisible = 'visible' in props ? visible : triggerVisible;

--- a/tests/props.test.tsx
+++ b/tests/props.test.tsx
@@ -1,0 +1,33 @@
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import Dropdown from '../src';
+
+const mockTriggerRender = jest.fn();
+
+jest.mock('@rc-component/trigger', () => {
+  const ReactModule: typeof React = jest.requireActual('react');
+
+  return {
+    __esModule: true,
+    default: ReactModule.forwardRef<HTMLElement, Record<string, unknown>>(
+      (props, ref) => {
+        mockTriggerRender(props);
+        return ReactModule.createElement('div', { ref });
+      },
+    ),
+  };
+});
+
+it('does not forward disabled to Trigger', () => {
+  const runtimeProps = { disabled: true };
+
+  render(
+    <Dropdown {...runtimeProps} visible overlay={<div />}>
+      <button type="button">open</button>
+    </Dropdown>,
+  );
+
+  const triggerProps = mockTriggerRender.mock.calls[0][0];
+  expect(triggerProps).not.toHaveProperty('disabled');
+  expect(triggerProps).toHaveProperty('popupVisible', true);
+});


### PR DESCRIPTION
## Summary

- filter the undeclared `disabled` prop before forwarding remaining props to Trigger
- preserve rc-dropdown controlled visibility behavior across Trigger upgrades
- add a regression test for the Trigger prop boundary

## Validation

- `ut compile`
- `ut test -- --runInBand`
- `ut tsc`
- `ut lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复下拉菜单禁用状态下，相关属性可能被错误传递到底层触发器组件的问题。
  * 确保禁用时弹层显示逻辑仍按预期工作，避免异常交互。
* **Tests**
  * 新增测试用例：验证禁用时触发器不会接收到禁用属性，并会正确获得弹层显示所需状态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->