### PR TITLE
fix: focus wrapped dropdown menus

### DIFF
--- a/src/hooks/useAccessibility.ts
+++ b/src/hooks/useAccessibility.ts
@@ -28,12 +28,22 @@ export default function useAccessibility({
   };
 
   const focusMenu = () => {
-    if (overlayRef.current?.focus) {
-      overlayRef.current.focus();
-      focusMenuRef.current = true;
-      return true;
+    const overlay = overlayRef.current;
+    if (!overlay?.focus) {
+      return false;
     }
-    return false;
+
+    const activeElement = document.activeElement;
+    overlay.focus();
+    if (document.activeElement === activeElement) {
+      const focusTarget = (overlay.querySelector?.('[role="menu"]') ??
+        overlay.querySelector?.('[tabindex]')) as HTMLElement | null;
+      focusTarget?.focus();
+    }
+
+    const focused = document.activeElement !== activeElement;
+    focusMenuRef.current = focused;
+    return focused;
   };
 
   const handleKeyDown = (event) => {

--- a/src/hooks/useAccessibility.ts
+++ b/src/hooks/useAccessibility.ts
@@ -28,7 +28,7 @@ export default function useAccessibility({
   };
 
   const focusMenu = () => {
-    const overlay = overlayRef.current;
+    const overlay = overlayRef?.current;
     if (!overlay?.focus) {
       return false;
     }

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -492,9 +492,16 @@ describe('dropdown', () => {
 
     // Focus menu with Tab
     window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 9 })); // Tab
+    expect(document.activeElement).toHaveClass('rc-menu');
+    fireEvent.keyDown(document.activeElement, {
+      key: 'ArrowDown',
+      keyCode: 40,
+    });
+    await sleep(50);
+    expect(document.activeElement).toHaveTextContent('one');
 
     // Close menu with Tab
-    window.dispatchEvent(new KeyboardEvent('keydown', { keyCode: 9 })); // Tab
+    fireEvent.keyDown(document.activeElement, { key: 'Tab', keyCode: 9 });
     await sleep(200);
     expect(document.activeElement.className).toContain('my-button');
   });


### PR DESCRIPTION
## Summary

- fall back from a non-focusable custom overlay wrapper to its nested menu or other explicit tab target
- only consume the first Tab press when focus actually moved
- strengthen the existing wrapped-menu regression to verify menu focus, ArrowDown navigation, and return focus

## Why

When Ant Design `popupRender` wraps a Menu in a plain element, Dropdown receives that wrapper as `overlayRef`. Plain elements expose `focus()` even when they are not focusable, so the hook previously treated the no-op call as success, prevented Tab, and left focus on the trigger. The nested Menu therefore never received the keyboard event path.

The fallback first attempts a nested `role="menu"`, preserving Menu keyboard behavior, and then an explicit `tabindex` target if menu focus did not move. Direct focusable overlays keep the existing path.

Related: ant-design/ant-design#50320

## Verification — September 20, 2026

Follow-up at signed/GitHub-Verified head `ed76a23a174be437a57d093d2228a7aa070661f1`.

Confirmed the fallback issue with a failing regression: a non-focusable `role="menu"` prevents the later tab target from receiving focus. The hook now attempts the tab target if menu focus did not move, forwarding the same focus options. Added controls for a missing menu and an omitted overlay ref. Full run: 6 suites / 31 tests / 1 snapshot pass; `useAccessibility.ts` has 100% statement/line coverage locally. TypeScript, ESM/CJS/declaration build and focused lint/format checks pass. This also exercises the early-return branch that the previous upstream patch coverage missed.

Remote checks for this new commit are separate from the local results above.

## AI assistance disclosure

Codex assisted with implementation, conflict resolution, regression tests, and validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误修复**
  * 改善菜单打开时的焦点定位：当覆盖层无法直接接收焦点时，将依次尝试菜单及其他可聚焦元素，并避免页面滚动。
  * 修复菜单被其他元素包裹时的键盘导航问题，使用 Tab 和方向键可更稳定地移动焦点并选择菜单项。
  * 改善菜单关闭及自动聚焦场景下的焦点处理，提升键盘操作的一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
